### PR TITLE
Ontology worker count not blocked by tree

### DIFF
--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/main.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/main.js
@@ -25,6 +25,7 @@ define([],function(){
 			"filter/searchResults" : "overrides/filter/searchResults",
 			"filter/searchResultTabs" : "overrides/filter/searchResultTabs",
 			"picSure/queryBuilder" : "overrides/query/queryBuilder",
+			"picSure/ontology" : "overrides/picSure/ontology",
 			"output/dataSelection" : "overrides/output/dataSelection",
 			"output/outputPanel" : "overrides/output/outputPanel"
 		}

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/dataSelection.hbs
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/dataSelection.hbs
@@ -1,5 +1,5 @@
 <div id="concept-tree"></div>
-<a class="center btn btn-default" id="prepare-btn">Prepare Download</a>
+<a class="center btn btn-default hidden" id="prepare-btn">Prepare Download</a>
 <a class="center btn btn-default hidden" download="data.csv" id="download-btn">Download</a>
 <div id="download-spinner"></div>
 <div id="resource-id-display"></div>

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/dataSelection.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/dataSelection.js
@@ -170,6 +170,7 @@ define(["common/spinner", "backbone", "handlebars", "text!output/dataSelection.h
 											childNode.text = childNode.text.replace(/<b\>.*<\/b>/,'') +  " <b>(" + crossCounts[child] + " observations in subset)</b>";
 											$('#concept-tree', this.$el).jstree().redraw_node(child);
 										}.bind(this));
+										$('#prepare-btn', this.$el).removeClass('hidden');
 									}.bind(this),
 									error: console.log
 								});
@@ -181,7 +182,6 @@ define(["common/spinner", "backbone", "handlebars", "text!output/dataSelection.h
 								this.selectedFields = _.without(this.selectedFields(node.id));
 							}.bind(this));
 							_.delay(function(){$('.jstree-node[aria-level=1] > .jstree-icon').click();}, 1000);
-							$('#prepare-btn').show();
 						}.bind(this))
 					, "#select-spinner"
 					, "select-spinner"

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/outputPanel.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/outputPanel.js
@@ -63,14 +63,6 @@ define(["text!../settings/settings.json","common/spinner", "output/dataSelection
 					query.query.expectedResultType="COUNT";
 					this.model.set("query", query);
 
-					if(!this.dataSelection){
-						this.dataSelection = new dataSelection({query:query});
-                                                $("#concept-tree-div",this.$el).append(this.dataSelection.$el);
-					} else {
-						this.dataSelection.updateQuery(query);
-					}
-					this.dataSelection.render();
-
 					var dataCallback = function(result){
 						this.model.set("totalPatients", parseInt(result));
 						$("#patient-count", this.$el).html(parseInt(result));
@@ -93,6 +85,13 @@ define(["text!../settings/settings.json","common/spinner", "output/dataSelection
 					 	data: JSON.stringify(query),
 					 	success: function(response){
 					 		dataCallback(response);
+								if(!this.dataSelection){
+									this.dataSelection = new dataSelection({query:query});
+									$("#concept-tree-div",this.$el).append(this.dataSelection.$el);
+								} else {
+									this.dataSelection.updateQuery(query);
+								}
+								this.dataSelection.render();
 					 	},
 					 	error: function(response){
 							if (response.status === 401) {

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/outputPanel.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/output/outputPanel.js
@@ -92,7 +92,7 @@ define(["text!../settings/settings.json","common/spinner", "output/dataSelection
 									this.dataSelection.updateQuery(query);
 								}
 								this.dataSelection.render();
-					 	},
+						}.bind(this),
 					 	error: function(response){
 							if (response.status === 401) {
 								localStorage.clear();

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
@@ -100,7 +100,6 @@ define(["underscore", "text!../settings/settings.json", "picSure/resourceMeta"],
         });
     };
     var counts = function(tree, allConcepts, crossCounts) {
-      allConceptsLoaded.then(function() {
         var total = 0;
         var folderCount = 0;
         _.each(tree.children, function(child) {
@@ -121,7 +120,6 @@ define(["underscore", "text!../settings/settings.json", "picSure/resourceMeta"],
             }
         });
         return total + tree.children.length - folderCount;
-      });
     }
 
     var autocomplete = function(query, done) {

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
@@ -175,6 +175,7 @@ define(["underscore", "text!../settings/settings.json", "picSure/resourceMeta"],
 
     var cachedTree;
 
+//*************   THIS IS WHAT DIVERGED FROM MASTER    **************//
     var ontologyWorker = new Worker('overrides/picSure/ontologyWorker.js');
         
     dictionary("\\", function(allConceptsRetrieved) {
@@ -183,8 +184,9 @@ define(["underscore", "text!../settings/settings.json", "picSure/resourceMeta"],
             cachedTree = event.data;
             allConceptsLoaded.resolve();
         }
-    ontologyWorker.postMessage([allConcepts]);
+    	ontologyWorker.postMessage([allConcepts]);
     });
+//******************************************************************//
 
     var allInfoColumnsQuery = {
         resourceUUID: JSON.parse(settings).picSureResourceId,

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
@@ -175,7 +175,7 @@ define(["underscore", "text!../settings/settings.json", "picSure/resourceMeta"],
 
     var cachedTree;
 
-//*************   THIS IS WHAT DIVERGED FROM MASTER    **************//
+//*************   THIS IS WHAT DIVERGED FROM MASTER 1 of 2   ********//
     var ontologyWorker = new Worker('overrides/picSure/ontologyWorker.js');
         
     dictionary("\\", function(allConceptsRetrieved) {
@@ -216,10 +216,12 @@ define(["underscore", "text!../settings/settings.json", "picSure/resourceMeta"],
     });
 
     var tree = function(consumer, crossCounts) {
+//*************   THIS IS WHAT DIVERGED FROM MASTER 2 of 2  *********//
             allConceptsLoaded.then(function() {
                 counts(cachedTree, allConcepts, crossCounts);
                 consumer(cachedTree);
             }.bind({cachedTree:cachedTree, consumer:consumer, crossCounts:crossCounts}));
+//******************************************************************//
     };
 
     var verifyPathsExist = function(paths, targetResource, done) {

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontology.js
@@ -1,0 +1,267 @@
+define(["underscore", "text!../settings/settings.json", "picSure/resourceMeta"], function(_, settings, resourceMeta) {
+    /*
+     * A function that takes a PUI that is already split on forward slash and returns
+     * the category value for that PUI.
+     */
+    var extractCategoryFromPui = function(puiSegments) {
+        return puiSegments[0];
+    };
+
+    /*
+     * A function that takes a PUI that is already split on forward slash and returns
+     * the parent value for that PUI.
+     */
+    var extractParentFromPui = function(puiSegments) {
+        return puiSegments[puiSegments.length - 2];
+    };
+
+    var mapResponseToResult = function(query, response, incomingQueryScope) {
+        var queryScope = [];
+        if (incomingQueryScope && incomingQueryScope.length > 0) {
+            queryScope = incomingQueryScope;
+        }
+
+        var result = {};
+        result.suggestions = [];
+        result.suggestions = _.filter(result.suggestions.concat(_.map(response.phenotypes,
+            entry => {
+                var puiSegments = entry.name.split("\\").filter(function(seg) {
+                    return seg.length > 0;
+                });
+                return {
+                    value: puiSegments[puiSegments.length - 1],
+                    data: entry.name,
+                    category: extractCategoryFromPui(puiSegments).replace(/[\W_]+/g, "_"),
+                    tooltip: entry.name,
+                    columnDataType: entry.categorical ? "CATEGORICAL" : "CONTINUOUS",
+                    metadata: entry,
+                    parent: extractParentFromPui(puiSegments)
+                };
+        }).sort(function(a, b) {
+            var indexOfTerm = a.value.toLowerCase().indexOf(query) - b.value.toLowerCase().indexOf(query);
+            var differenceInLength = a.value.length - b.value.length;
+            //                      return indexOfTerm == 0 ? indexOfTerm + differenceInLength : indexOfTerm;
+            return (indexOfTerm * 1000) + differenceInLength;
+        }).concat(_.map(response.genes, entry => {
+            var puiSegments = ["Genes", entry.name]; //entry.name.split("\\").filter(function(seg){return seg.length > 0;});
+            return {
+                value: entry.name,
+                data: entry.name,
+                category: "Genes",
+                tooltip: entry.name,
+                columnDataType: "VARIANT",
+                metadata: entry,
+                parent: "Chromosome " + entry.chr
+            };
+        }).sort(function(a, b) {
+            var indexOfTerm = a.value.toLowerCase().indexOf(query) - b.value.toLowerCase().indexOf(query);
+            var differenceInLength = a.value.length - b.value.length;
+            //          return indexOfTerm == 0 ? indexOfTerm + differenceInLength : indexOfTerm;
+            return (indexOfTerm * 1000) + differenceInLength;
+        })).concat(_.map(_.keys(response.info), key => {
+            var entry = response.info[key];
+            return {
+                value: entry.description,
+                data: entry.description,
+                category: key,
+                tooltip: entry.description,
+                columnDataType: "INFO",
+                metadata: entry,
+                parent: "Variant Info"
+            };
+        }).sort(function(a, b) {
+            var indexOfTerm = a.value.toLowerCase().indexOf(query) - b.value.toLowerCase().indexOf(query);
+            var differenceInLength = a.value.length - b.value.length;
+            //          return indexOfTerm == 0 ? indexOfTerm + differenceInLength : indexOfTerm;
+            return (indexOfTerm * 1000) + differenceInLength;
+        }))),function(element){return queryScope.length>0 ? queryScope.includes(element.category):true});
+        if (result.length > 1000) {
+            result = result.slice(0, 999);
+        }
+        return result;
+    };
+
+    var searchCache = {};
+
+    var dictionary = function(query, success, error) {
+        return $.ajax({
+            url: window.location.origin + '/picsure/search/' + JSON.parse(settings).picSureResourceId,
+            data: JSON.stringify({
+                "query": query
+            }),
+            headers: {
+                "Authorization": "Bearer " + JSON.parse(sessionStorage.getItem("session")).token
+            },
+            contentType: 'application/json',
+            type: 'POST',
+            success: success,
+            error: error,
+            dataType: "json"
+        });
+    };
+    var counts = function(tree, allConcepts, crossCounts) {
+      allConceptsLoaded.then(function() {
+        var total = 0;
+        var folderCount = 0;
+        _.each(tree.children, function(child) {
+            var count = counts(child, allConcepts, crossCounts);
+            if (count > 0) {
+                folderCount++;
+            }
+            total += count;
+            child.text = child.text.replace(/(\([0-9]+ [a-z]+\))+$/, "");
+            if (count == 0) {
+                if (crossCounts !== undefined) {
+                    child.text += " (" + crossCounts[child.id] + " observations in subset)";
+                } else {
+                    child.text += " (" + allConcepts.results.phenotypes[child.id].observationCount + " observations)";
+                }
+            } else {
+                child.text += " (" + (count == 0 ? 1 + " concept)" : count + " concepts)");
+            }
+        });
+        return total + tree.children.length - folderCount;
+      });
+    }
+
+    var autocomplete = function(query, done) {
+
+        return dictionary(
+            query,
+            function(response) {
+                $.ajax({
+                    url: window.location.origin + "/psama/user/me",
+                    type: 'GET',
+                    headers: {"Authorization": "Bearer " + JSON.parse(sessionStorage.getItem("session")).token},
+                    contentType: 'application/json',
+                    success: function(meResponse){
+                        var result = mapResponseToResult(query, response.results, meResponse.queryScopes);
+                        searchCache[query.toLowerCase()] = result;
+                        done(result);
+                    }.bind(this),
+                    error: function(response){
+                        console.log("error retrieving user info");
+                        console.log(response);
+                        if (response.status === 401) {
+                            sessionStorage.clear();
+                            window.locaion = "/";
+                        }
+                    }.bind(this)
+                });
+            }.bind({
+                done: done
+            }),
+            function(response) {
+                if (response.status === 401) {
+                    sessionStorage.clear();
+                    window.location = "/";
+                } else {
+                    searchCache[query.toLowerCase()] = [];
+                    done({
+                        suggestions: []
+                    });
+                }
+            })
+    }.bind({
+        resourceMeta: resourceMeta
+    });
+
+    var allConcepts;
+    var allInfoColumns;
+
+    var allConceptsLoaded = $.Deferred();
+
+    var allInfoColumnsLoaded = $.Deferred();
+
+    var cachedTree;
+
+    var ontologyWorker = new Worker('overrides/picSure/ontologyWorker.js');
+        
+    dictionary("\\", function(allConceptsRetrieved) {
+        allConcepts = allConceptsRetrieved;
+        ontologyWorker.onmessage = function(event){
+            cachedTree = event.data;
+            allConceptsLoaded.resolve();
+        }
+    ontologyWorker.postMessage([allConcepts]);
+    });
+
+    var allInfoColumnsQuery = {
+        resourceUUID: JSON.parse(settings).picSureResourceId,
+        query: {
+
+            expectedResultType: "INFO_COLUMN_LISTING"
+        }
+    };
+
+    $.ajax({
+        url: window.location.origin + "/picsure/query/sync",
+        type: 'POST',
+        headers: {
+            "Authorization": "Bearer " + JSON.parse(sessionStorage.getItem("session")).token
+        },
+        contentType: 'application/json',
+        dataType: 'json',
+        data: JSON.stringify(allInfoColumnsQuery),
+        success: function(response) {
+            allInfoColumns = response;
+            allInfoColumnsLoaded.resolve();
+        }.bind(this),
+        error: function(response) {
+            console.log("error retrieving info columns");
+            console.log(response);
+        }.bind(this)
+    });
+
+    var tree = function(consumer, crossCounts) {
+            allConceptsLoaded.then(function() {
+                counts(cachedTree, allConcepts, crossCounts);
+                consumer(cachedTree);
+            }.bind({cachedTree:cachedTree, consumer:consumer, crossCounts:crossCounts}));
+    };
+
+    var verifyPathsExist = function(paths, targetResource, done) {
+        if (!localStorage.getItem("id_token")) {
+            done(false);
+            var resolved = $.Deferred();
+            resolved.resolve();
+            return resolved;
+        }
+        return $.ajax({
+            url: window.location.origin + '/picsure/search/' + JSON.parse(settings).picSureResourceId,
+            headers: {
+                "Authorization": "Bearer " + JSON.parse(sessionStorage.getItem("session")).token
+            },
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                "query": paths[0]
+            }),
+            success: function(response) {
+                done(true);
+            },
+            error: function(response) {
+                done(false);
+            }
+        });
+    };
+
+    var allInfoColumns_ = function() {
+        return allInfoColumns;
+    };
+
+    var allConcepts_ = function() {
+        return allConcepts;
+    };
+
+    return {
+        dictionary: dictionary,
+        tree: tree,
+        autocomplete: autocomplete,
+        verifyPathsExist: verifyPathsExist,
+        allConcepts: allConcepts_,
+        allInfoColumns: allInfoColumns_,
+        allInfoColumnsLoaded: allInfoColumnsLoaded
+    };
+
+});

--- a/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontologyWorker.js
+++ b/httpd/pic-sure-hpds-ui-copdgene/src/main/webapp/picsureui/overrides/picSure/ontologyWorker.js
@@ -1,0 +1,33 @@
+importScripts('/picsureui/webjars/underscorejs/1.8.3/underscore-min.js');
+onmessage = function(event){
+	var allConcepts = event.data[0];
+	var tree = {
+        text: "data",
+        state: {
+            open: true,
+            disabled: true
+        },
+        children: []
+    };
+    Object.keys(allConcepts.results.phenotypes).forEach(function(concept) {
+        var segments = concept.split("\\");
+        var currentNode = tree;
+        for (var x = 1; x < segments.length - 1; x++) {
+            if (currentNode.children[_.findIndex(currentNode.children, function(child) {
+                return child.text.includes(segments[x])
+            })] === undefined) {
+                var newNode = {
+                    id: segments.slice(0, x + 1).join("\\") + "\\",
+                    text: segments[x],
+                    children: []
+                };
+                currentNode.children.push(newNode);
+            }
+            currentNode = currentNode.children[_.findIndex(currentNode.children, function(child) {
+                return child.text.includes(segments[x])
+            })];
+        }
+    });
+    var cachedTree = JSON.parse(JSON.stringify(tree));
+    postMessage(cachedTree);            
+};


### PR DESCRIPTION
This is not a real fix. It just makes it better, but not as good as it could be. We will need to investigate alternative tree implementations or build one of our own.

The complexity in this actually comes from the requirement for checking a top level node in the tree implying that it's sub-hierarchy is included in the export. If we lazy-load, there are no sub-hierarchies until the user expands.

One possibility is to handle it using the same approach as clicking the hierarchy nodes in the search results, but we don't have time right now to explore that.